### PR TITLE
Fix points rendering for Chrome on Mac.

### DIFF
--- a/web-root/scripts/sat.js
+++ b/web-root/scripts/sat.js
@@ -202,6 +202,7 @@ satSet.draw = function(pMatrix, camMatrix) {
     
     gl.bindBuffer(gl.ARRAY_BUFFER, satPosBuf);
     gl.bufferData(gl.ARRAY_BUFFER, satPos, gl.STREAM_DRAW);
+    gl.enableVertexAttribArray(dotShader.aPos);
     gl.vertexAttribPointer(dotShader.aPos, 3, gl.FLOAT, false, 0, 0);
     
     gl.bindBuffer(gl.ARRAY_BUFFER, satColorBuf);


### PR DESCRIPTION
This vertex attribute was used without being enabled.

On almost every platform, it so happened that the attributes here were
being assigned integer values that made the app work correctly. However,
this vertex attribute was actually relying on a vertex attrbute enabled
for one of the other draw calls. In Chrome on Mac, the vertex attributes for
the picking shader are 2,0,1 (or something like that), while they are
2,1,0 on Firefox. This seems like it's probably a property of the GL
driver; maybe Firefox works around it.